### PR TITLE
Avoid hitting the command line length limit if compiler variables with long values are configured

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <repositories>
+    <repository>
+      <id>ejt</id>
+      <name>ej-technologies</name>
+      <url>http://maven.ej-technologies.com/repository</url>
+    </repository>
+  </repositories>
+
   <parent>
     <groupId>org.sonatype.buildsupport</groupId>
     <artifactId>public-parent</artifactId>


### PR DESCRIPTION
The maximum length of the command line can be quite low (8192 on Windows). In the upcoming install4j 6.1 release it will be possible to pass lists of files in compiler variables that can be added to the distribution tree or launcher classpaths. To avoid problems with truncated command lines, this patch passes compiler variables in a temporary file that is deleted after the execution. This change is backwards-compatible with install4j versions down to 4.1.5.

Also, the install4j runtime is now available in a repository. I've added it to the top-level pom, please change as appropriate.