### PR TITLE
Added a parameter for setting the license key.

### DIFF
--- a/install4j-maven-plugin/src/main/java/org/sonatype/install4j/maven/CompileMojo.java
+++ b/install4j-maven-plugin/src/main/java/org/sonatype/install4j/maven/CompileMojo.java
@@ -70,6 +70,13 @@ public class CompileMojo
   private boolean quiet;
 
   /**
+   * Sets the license key. This is only necessary if the license key has not been set during the
+   * installation of install4j for this machine and the current user. Only supported for install4j 6.1 and higher.
+   */
+  @Parameter(property = "install4j.license")
+  private String license;
+
+  /**
    * Enables test mode. In test mode, no media files will be generated in the media file directory.
    */
   @Parameter(property = "install4j.test", defaultValue = "false")
@@ -210,6 +217,11 @@ public class CompileMojo
 
     if (quiet) {
       task.createArg().setValue("--quiet");
+    }
+
+    if (license != null) {
+      task.createArg().setValue("--license");
+      task.createArg().setValue(license);
     }
 
     if (test) {


### PR DESCRIPTION
In install4j 6.1, it will be possible to set the license key when invoking the command line compiler.
The argument "--license" is recognized by earlier versions of install4j as well, where the compiler exits after updating the licensing information.