### PR TITLE
Revert unpublished addition of the install4j.appleId parameter.

### DIFF
--- a/install4j-maven-plugin/src/main/java/org/sonatype/install4j/maven/CompileMojo.java
+++ b/install4j-maven-plugin/src/main/java/org/sonatype/install4j/maven/CompileMojo.java
@@ -124,12 +124,6 @@ public class CompileMojo
   private String macKeystorePassword;
 
   /**
-   * Set the Apple ID used for notarizing macOS media files. This only has an effect when run on a macOS machine.
-   */
-  @Parameter(property = "install4j.appleId")
-  private String appleId;
-
-  /**
    * Set the app-specific password for notarizing macOS media files. This only has an effect when run on a macOS machine.
    */
   @Parameter(property = "install4j.appleIdPassword")
@@ -260,11 +254,6 @@ public class CompileMojo
     if (macKeystorePassword != null) {
       task.createArg().setValue("--mac-keystore-password");
       task.createArg().setValue(macKeystorePassword);
-    }
-
-    if (appleId != null) {
-      task.createArg().setValue("--apple-id");
-      task.createArg().setValue(appleId);
     }
 
     if (appleIdPassword != null) {


### PR DESCRIPTION
In install4j 8.0.3, the Apple ID is configured on the "General Settings->Code Signing" step and there is an associated explicit activation of notarization in the project rather than the external activation through the install4j.appleId parameter. This is now consistent with other signing modes that are fully configured in the project file except for passwords.