### PR TITLE
Jenkins port

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 @Library(['private-pipeline-library', 'jenkins-shared@mvnw']) _
 
 mavenPipeline(
-  javaVersion: 'Java 7',
+  javaVersion: 'Java 8',
   useMvnw: true,
   usePublicSettingsFile: true,
   useEventSpy: false, 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,9 @@
+@Library(['private-pipeline-library', 'jenkins-shared@mvnw']) _
+
+mavenPipeline(
+  javaVersion: 'Java 7',
+  useMvnw: true,
+  usePublicSettingsFile: true,
+  useEventSpy: false, 
+  testResults: [ '**/target/*-reports/*.xml' ]
+)


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/NEXUS-16030
Working build: https://jenkins.ci.sonatype.dev/job/internal/job/install4j-support/job/feature-snapshots/job/jenkins/lastBuild/

Bamboo job:  http://bamboo.s/browse/PVT-I4JS

Old Bamboo job used Java 7, but that JDK doesn't seem to actually work in Jenkins anymore.  If it really needs to be built on Java 7 rather than Java 8, let me know and I can work to get that functional.

This is the first project to use `mvnw` so I needed to update jenkins-shared to support that.  That should be merged and this @mvnw annotation removed before this is merged.

Let me know if you have any questions/concerns!